### PR TITLE
develop server에 배포 실패 수정

### DIFF
--- a/.github/workflows/django_CD_dev.yml
+++ b/.github/workflows/django_CD_dev.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - 'django/seoulInfoProject/**'
-      - '!django/seoulInfoProject/static/**'
+    #   - '!django/seoulInfoProject/static/**'
       - '!**.md'
     branches: [ "develop" ]
 
@@ -30,9 +30,4 @@ jobs:
         proxy_key: ${{ secrets.SSH_KEY }}
         proxy_port: 22
         script: |
-          cd project4-team1
-          git branch -m develop && git reset --hard origin/develop
-          cd django && rm -rf venv
-          python3 -m venv venv && cd seoulInfoProject
-          source /home/ubuntu/project4-team1/django/venv/bin/activate && pip install -r requirements.txt > pip.log
-        #   python manage.py runserver --settings=seoulInfoProject.settings.debug
+          source git-clone-force.sh > git-clone-force.log


### PR DESCRIPTION
### Issus number
Django_CD_dev 최신 commit 적용 안됨 #25 


### PR 타입
**버그 수정**


### 변경 사항
1. private 서버에 쉘 스크립트 생성
2. 기존의 CD 코드에서 reset 커맨드 제거 후 clone로 변경
    2-1. clone은 force가 불가능 -> rm -rf 명령으로 프로젝트 폴더 삭제를 먼저 진행
4. workflow의 django_cd_dev.yml 변경 -> 해당 쉘 스크립트 실행

![image](https://github.com/data-dev-course/project4-team1/assets/89768234/c0c53789-aea4-4387-a0f9-03985dab16b4)
